### PR TITLE
Removed horizontal bar

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -2,6 +2,7 @@ body,
 html {
     height: 100vh;
     width: 100vw;
+    overflow-x: hidden;
 }
 
 .box {


### PR DESCRIPTION
Added the overflox-x attribute and set the value to hidden to prevent the horizontal navigation bar from appearing.